### PR TITLE
Fix date weekday mismatch

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -846,7 +846,8 @@ main {
 
 /* 恢复 flatpickr 默认的 weekday header 显示 */
 .flatpickr-weekdays {
-  display: flex !important;
+  display: grid !important;
+  grid-template-columns: repeat(7, 1fr) !important;
 }
 
 /* 移除自定义 weekday header 样式 */
@@ -856,8 +857,8 @@ main {
 
 .flatpickr-days {
   width: 100% !important;
-  display: flex !important;
-  flex-wrap: wrap !important;
+  display: grid !important;
+  grid-template-columns: repeat(7, 1fr) !important;
   background-color: transparent !important;
 }
 
@@ -865,9 +866,7 @@ main {
   width: 100% !important;
   min-width: 100% !important;
   max-width: 100% !important;
-  display: flex !important;
-  flex-wrap: wrap !important;
-  justify-content: flex-start !important;
+  display: contents !important;
   padding: 0 !important;
 }
 
@@ -877,8 +876,7 @@ main {
   line-height: 36px !important;
   border-radius: 50% !important;
   max-width: 36px !important;
-  width: calc(100% / 7 - 4px) !important;
-  flex: 0 0 calc(100% / 7 - 4px) !important;
+  width: 100% !important;
   display: inline-flex !important;
   justify-content: center !important;
   align-items: center !important;

--- a/js/app.js
+++ b/js/app.js
@@ -959,13 +959,22 @@ function toggleView() {
 }
 
 function formatDate(dateString) {
-  const date = new Date(dateString);
-  return date.toLocaleDateString('en-US', {
+  const [year, month, day] = dateString.split('-').map(Number);
+  // 使用 UTC 时间构造日期以避免时区差异
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  // 手动计算星期以确保始终与日期匹配
+  const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  const weekday = weekdays[date.getUTCDay()];
+
+  const formatted = date.toLocaleDateString('en-US', {
+    timeZone: 'UTC',
     year: 'numeric',
     month: 'numeric',
-    day: 'numeric',
-    weekday: 'short'
+    day: 'numeric'
   });
+
+  return `${formatted}, ${weekday}`;
 }
 
 async function loadPapersByDateRange(startDate, endDate) {


### PR DESCRIPTION
## Summary
- parse dates in UTC to avoid timezone issues
- ensure weekday names calculated in UTC
- update date picker grid layout so rows have exactly 7 days

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685cfcecf8b48333a5b2ce9cd0a5302a